### PR TITLE
use langserver for js/ts

### DIFF
--- a/vim/plugin/plug-languageclient-neovim.vim
+++ b/vim/plugin/plug-languageclient-neovim.vim
@@ -7,6 +7,15 @@ augroup dkolanguageclient
 augroup END
 
 " Autostarted in LanguageClient-neovim
-if dko#IsPlugged('roxma/LanguageServer-php-neovim')
-  autocmd dkolanguageclient FileType php LanguageClientStart
+if dko#IsLoaded('roxma/LanguageServer-php-neovim')
+  autocmd dkolanguageclient FileType javascript LanguageClientStart
+  autocmd dkolanguageclient FileType php        LanguageClientStart
+endif
+
+let g:LanguageClient_serverCommands = {}
+"\ 'rust': ['rustup', 'run', 'nightly', 'rls'],
+
+let s:langserver_js = glob('~/src/javascript-typescript-langserver/lib/language-server-stdio.js')
+if !empty(s:langserver_js)
+  let g:LanguageClient_serverCommands.javascript = [ s:langserver_js ]
 endif

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -782,7 +782,10 @@ function! s:LoadPlugins() abort
   " --------------------------------------------------------------------------
 
   " Code analysis completion
-  let l:use_tern = g:dko_use_completion && executable('npm')
+  let g:langserver_js = glob('~/src/javascript-typescript-langserver/lib/language-server-stdio.js')
+  let l:use_tern = g:dko_use_completion
+        \ && empty(g:langserver_js)
+        \ && executable('npm')
 
   " faster than deoplete implementation
   Plug 'roxma/nvim-cm-tern', PlugIf(l:use_tern, { 'do': 'npm install' })
@@ -833,11 +836,9 @@ function! s:LoadPlugins() abort
         \ })
 
   " The language client completion is a bit slow to kick in, but it works
-  " Plug 'autozimu/LanguageClient-neovim', { 'do': ':UpdateRemotePlugins' }
-  "       \|  Plug 'roxma/LanguageServer-php-neovim', {
-  "       \     'do': 'composer install && composer run-script parse-stubs'
-  "       \   }
-  " else
+  " Plug 'roxma/LanguageServer-php-neovim', PlugIf(l:use_lsp, {
+  "   \   'do': 'composer install && composer run-script parse-stubs'
+  "   \ })
 
   " Possible vanilla plugins
   " 'phpvim/phpcd.vim'              - server based completion
@@ -897,7 +898,10 @@ function! s:LoadPlugins() abort
   " special end syntax for various langs
   Plug 'tpope/vim-endwise'
 
-  "Plug 'autozimu/LanguageClient-neovim', { 'do': ':UpdateRemotePlugins' }
+  let l:use_lsp = has('nvim')
+  Plug 'autozimu/LanguageClient-neovim', PlugIf(l:use_lsp, {
+        \   'do': ':UpdateRemotePlugins',
+        \ })
 
   " ==========================================================================
   " Language: bash/shell/zsh


### PR DESCRIPTION
Channel ID tends to get lost in JS and trigger CursorMoved/TextChanged in a loop.
Maybe need to disable other completion sources (e.g. jspc) that modify cursorpos